### PR TITLE
fix(nfs-client-multiple): add mount opt 'nolock', fix deploy yaml, update version

### DIFF
--- a/nfs-client-multiple/Makefile
+++ b/nfs-client-multiple/Makefile
@@ -26,7 +26,7 @@
 #
 
 # Current version of the project.
-VERSION ?= v0.0.1
+VERSION ?= v0.0.2-alpha.1
 GIT_SHA=$(shell git rev-parse --short HEAD)
 TAGS=$(GIT_SHA)
 

--- a/nfs-client-multiple/deploy/class.yaml
+++ b/nfs-client-multiple/deploy/class.yaml
@@ -4,6 +4,6 @@ metadata:
   name: nfs-001
   provisioner: caicloud.io/nfs # or choose another name, must match deployment's env ENV_PROVISION_NAME'
 parameters:
-  server: 192.168.3.4
-  exportPath: /export/nfs/data1
+  server: 192.168.17.32
+  exportPath: /root/zxq/data/nfs
   readOnly: false

--- a/nfs-client-multiple/deploy/class.yaml
+++ b/nfs-client-multiple/deploy/class.yaml
@@ -1,8 +1,9 @@
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: nfs-001
-provisioner: caicloud.io/nfs # or choose another name, must match deployment's env ENV_PROVISION_NAME'
+  provisioner: caicloud.io/nfs # or choose another name, must match deployment's env ENV_PROVISION_NAME'
+parameters:
   server: 192.168.3.4
   exportPath: /export/nfs/data1
   readOnly: false

--- a/nfs-client-multiple/deploy/deployment.yaml
+++ b/nfs-client-multiple/deploy/deployment.yaml
@@ -14,13 +14,13 @@ spec:
       labels:
         caicloud-app: nfs-multiple-provisioner
         caicloud.io/cluster-service: "true"
-        kubernetes-admin.caicloud.io/application: nfs-multiple-provisioner-v0.0.1
+        kubernetes-admin.caicloud.io/application: nfs-multiple-provisioner-v0.0.2-alpha.1
         kubernetes-admin.caicloud.io/type: application
-        version: v0.0.1
+        version: v0.0.2-alpha.1
     spec:
       containers:
         - name: nfs-multiple-provisioner
-          image: cargo.caicloudprivatetest.com/caicloud/storage-nfs-multiple-provisioner:v0.0.1
+          image: cargo.caicloudprivatetest.com/caicloud/storage-nfs-multiple-provisioner:v0.0.2-alpha.1
           env:
             - name: ENV_KUBE_MASTER
               value: ""

--- a/nfs-client-multiple/deploy/test-claim.yaml
+++ b/nfs-client-multiple/deploy/test-claim.yaml
@@ -4,7 +4,7 @@ metadata:
   name: test-nfs-pvc
   namespace: default
   annotations:
-    volume.beta.kubernetes.io/storage-class: "nfs"
+    volume.beta.kubernetes.io/storage-class: "nfs-001"
 spec:
   accessModes:
     - ReadWriteMany

--- a/nfs-client-multiple/deploy/test-claim.yaml
+++ b/nfs-client-multiple/deploy/test-claim.yaml
@@ -2,7 +2,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: test-nfs-pvc
-  namespace: test
+  namespace: default
   annotations:
     volume.beta.kubernetes.io/storage-class: "nfs"
 spec:

--- a/nfs-client-multiple/deploy/test-pod.yaml
+++ b/nfs-client-multiple/deploy/test-pod.yaml
@@ -5,12 +5,12 @@ metadata:
 spec:
   containers:
   - name: test-pod
-    image: gcr.io/google_containers/busybox:1.24
+    image: cargo.caicloudprivatetest.com/caicloud/storage-nfs-multiple-provisioner:v0.0.2-alpha.1
     command:
       - "/bin/sh"
     args:
       - "-c"
-      - "touch /mnt/SUCCESS && exit 0 || exit 1"
+      - "touch /mnt/SUCCESS && mkdir /mnt/DIR && echo xxx > /mnt/DIR/FFF && exit 0 || exit 1"
     volumeMounts:
       - name: nfs-pvc
         mountPath: "/mnt"

--- a/nfs-client-multiple/pkg/provision/const.go
+++ b/nfs-client-multiple/pkg/provision/const.go
@@ -33,6 +33,12 @@ const (
 	MountStatusNew       = 0
 	MountStatusMounted   = 1
 	MountStatusUnmounted = 2
+
+	MountOptNolock = "nolock"
+)
+
+var (
+	DefaultMountOpts = []string{MountOptNolock}
 )
 
 var (

--- a/nfs-client-multiple/pkg/provision/manager.go
+++ b/nfs-client-multiple/pkg/provision/manager.go
@@ -63,7 +63,7 @@ func (mm *MountManager) GetByPath(server, exportPath string) (*MountHandler, err
 	if e != nil {
 		return nil, e
 	}
-	e = mh.Mount(mm.mountBase, nil, mm.mounter)
+	e = mh.Mount(mm.mountBase, DefaultMountOpts, mm.mounter)
 	if e != nil {
 		return nil, e
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

- fix deploy yaml
  - storage package version
  - provisioner name
  - reformat
- add mount options 'nolock'
  - it said need service rpc.statd, but in container it's not good to make one, so just add a mount option
- update version to v0.0.2-alpha.1

**Which issue(s) this PR fixes** *(optional, close the issue(s) when PR gets merged)*:

Fixes #

**Special notes for your reviewer**:

/cc @your-reviewer

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
add mount opt 'nolock', fix deploy yaml, update version to v0.0.2-alpha.1
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/docs/review_conventions.md  <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/docs/commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/docs/caicloud_bot.md        <-- how to work with caicloud bot

Other tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
